### PR TITLE
Add logging

### DIFF
--- a/src/D2App.ClientApi/D2App.ClientApi.csproj
+++ b/src/D2App.ClientApi/D2App.ClientApi.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\D2App.Application\D2App.Application.csproj" />
     <ProjectReference Include="..\D2App.Shared\D2App.Shared.csproj" />
+    <ProjectReference Include="..\D2App.Infrastructure\D2App.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/D2App.ClientApi/Program.cs
+++ b/src/D2App.ClientApi/Program.cs
@@ -1,39 +1,57 @@
-var builder = WebApplication.CreateBuilder(args);
+using D2App.Infrastructure;
+using Serilog;
 
-// Add services to the container.
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
-
-var app = builder.Build();
-
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+DIServices.BootstrapSerilogTemporarily();
+try
 {
-    app.MapOpenApi();
+    var builder = WebApplication.CreateBuilder(args);
+
+    builder.AddInfrastructure();
+    builder.Services.AddOpenApi();
+
+    var app = builder.Build();
+
+    app.UseInfrastructure();
+
+    if (app.Environment.IsDevelopment())
+    {
+        app.MapOpenApi();
+    }
+
+    app.UseHttpsRedirection();
+
+    var summaries = new[]
+    {
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    app.MapGet("/weatherforecast", (ILogger<Program> logger) =>
+    {
+
+        logger.LogInformation("HELLO WORLD");
+        var forecast = Enumerable.Range(1, 5).Select(index =>
+            new WeatherForecast
+            (
+                DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                Random.Shared.Next(-20, 55),
+                summaries[Random.Shared.Next(summaries.Length)]
+            ))
+            .ToArray();
+        return forecast;
+    })
+    .WithName("GetWeatherForecast");
+
+    app.Run();
+}
+catch (Exception ex)
+{
+    DIServices.LogApplicationException(ex, "An unhandled exception occurred durring bootstrapping of the application");
+}
+finally
+{
+    DIServices.LogAndFlush();
 }
 
-app.UseHttpsRedirection();
-
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast");
-
-app.Run();
 
 record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {

--- a/src/D2App.ClientApi/Properties/launchSettings.json
+++ b/src/D2App.ClientApi/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5249",
+      "applicationUrl": "http://localhost:5001",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7041;http://localhost:5249",
+      "applicationUrl": "https://localhost:7041;http://localhost:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/src/D2App.ClientApi/appsettings.Development.json
+++ b/src/D2App.ClientApi/appsettings.Development.json
@@ -1,8 +1,36 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+  "Serilog": {
+    "Using": [ 
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.File",
+      "Serilog.Expressions",
+      "Serilog.Formatting.Compact",
+      "Serilog.Sinks.Seq"
+    ],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Information",
+        "System": "Information",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.AspNetCore": "Information"
+      }
+    },
+    "Enrich": [ "FromLogContext" ],
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "template": "[{@t:HH:mm:ss} {@l:u3} ({SourceContext})]{#if TraceId is not null}Trace Id: {@tr}{#end}{#if SpanId is not null}Span Id: {@sp}{#end}{#if EventId is not null}Event Id: {@i}{#end} {@m}\n{@x}",
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
+        }
+      },
+      {
+        "Name": "Seq",
+        "Args": {
+          "serverUrl": "http://d2app-seq:5341"
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
---

**Title**: Implement Logging Using Serilog in .NET Core WebAPI

**Description**:  
To ensure structured and consistent logging throughout the application, we need to integrate **Serilog** into the .NET Core WebAPI project. Serilog provides powerful, extensible logging capabilities, including support for structured logging, sinks for various targets (file, console, Seq, etc.), and integration with Microsoft.Extensions.Logging.

**Acceptance Criteria**:
- [x] Serilog is added to the project via NuGet packages.
- [x] Logging is configured in `Program.cs` (or `Startup.cs` if applicable).
- [x] Logs are written to:
  - Console (for development)
  - File (with daily rolling logs)
- [x] Serilog is configured using `appsettings.json` (override with environment-specific settings as needed).
- [x] Structured logging is implemented using log templates (e.g., `{@User}`, `{RequestId}`, etc.).
- [x] Application lifecycle events (startup, shutdown) are logged.
- [x] Example usage of logging is implemented in at least one controller or service class.
- [x] Logging is resilient to failures (e.g., sink failures don’t crash the app).
- [x] Optional: Integrate Seq or other log aggregation tools in future tasks.

**Tasks**:
1. Install necessary Serilog NuGet packages:
   - `Serilog.AspNetCore`
   - `Serilog.Sinks.Console`
   - `Serilog.Sinks.File`
2. Configure Serilog at application startup.
3. Add logging settings in `appsettings.json`.
4. Inject and use `ILogger<T>` in a sample controller.
5. Verify logs are written correctly to the console and file.
6. Document logging setup in the project README.

**Additional Notes**:
- Follow Clean Architecture principles — logging should be centralized in the `Infrastructure` or `Logging` layer if using a layered architecture.
- Use correlation IDs or request tracing where possible for easier log tracing.
- Make sure sensitive data is never logged.

**Priority**: Medium  
**Estimated Effort**: 3-5 hours  
**Labels**: `enhancement`, `logging`, `serilog`, `backend`

---

close #2 